### PR TITLE
fix: better dependency counting

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,14 +27,66 @@ const CANCELLATION_MESSAGE = isNoColourMode()
 	? 'Action cancelled by user; no new packages installed.'
 	: '\x1b[1;31mAction cancelled by user\x1b[1;0m; no new packages installed.'
 
+/*
+ *  Builds a collection of new dependencies based on resolved packages and known added
+ *  package names.
+ *
+ *  Returns a single collection containing the flattened dependency subtrees rooted
+ *  at each of the added packages.
+ *
+ *  @param {Map<LocatorHash, Locator>} packageLocators Stored locators from the Yarn Project.
+ *  @param {Map<DescriptorHash, Descriptor>} packageDescriptors Stored descriptors from the Yarn Project.
+ *  @param {Array<string>} addedDescriptorHashes Top-level package descriptor hashes being added.
+ */
+function determineNewDependencies(storedPackages, packageDescriptors, addedIdentHashes) {
+	const packagesByIdentHash = new Map()
+
+	for (const storedPackage of storedPackages.values()) {
+		packagesByIdentHash.set(storedPackage.identHash, storedPackage)
+	}
+
+	const addedPackagesMap = new Map()
+
+	const identHashStack = [...addedIdentHashes]
+
+	while (identHashStack.length > 0) {
+		const addedHash = identHashStack.pop()
+		const addedPackage = packagesByIdentHash.get(addedHash)
+
+		// Multiple packages may depend on the same package. We only
+		// track it once.
+		if (!addedPackagesMap.has(addedHash)) {
+			addedPackagesMap.set(addedHash, addedPackage)
+			identHashStack.push(...addedPackage.dependencies.keys())
+		}
+	}
+
+	return addedPackagesMap
+}
+
 module.exports = {
 	name: 'plugin-new-dependency-check',
 	factory: (require) => {
 		const { ThrowReport } = require('@yarnpkg/core')
 		const readline = require('readline')
 
+		const state = {
+			addedTopLevelPackages: undefined,
+			addedIdentHashes: new Set(),
+		}
+
 		return {
 			hooks: {
+				/*
+				 * afterWorkspaceDependencyAddition?: (
+				 *  workspace: Workspace,
+				 *  target: suggestUtils.Target,
+				 *  descriptor: Descriptor,
+				 *  strategies: Array<suggestUtils.Strategy>
+				 * )() => Promise<void>
+				 *
+				 * See hook documentation: https://yarnpkg.com/advanced/plugin-tutorial#hook-afterWorkspaceDependencyAddition
+				 */
 				async afterWorkspaceDependencyAddition(workspace, target, descriptor, strategies) {
 					/*
 					 * To determine how many additional packages will be installed, we compare
@@ -43,8 +95,34 @@ module.exports = {
 					 * The difference of descriptor maps should reveal which have been added (which would be
 					 * added packages).
 					 */
-					// FIXME: This won't necessarily be a good account of what's already installed.
-					const currentDescriptors = workspace.project.storedDescriptors
+
+					/*
+					 * This hook is executed for each added dependency such that
+					 * `yarn add A B C` will call it thrice. To avoid this, we can
+					 * parse the command-line arguments to determine what the user is
+					 * trying to add.
+					 */
+					state.addedTopLevelPackages =
+						state.addedTopLevelPackages ||
+						process.argv.filter((arg, position) => {
+							// The first three arguments are the node and yarn runtime paths, and
+							// the add command.
+							if (position < 3) return false
+
+							// Flags passed to `yarn add` are ignored.
+							if (arg.startsWith('-')) return false
+
+							return true
+						})
+
+					// Keeping track of descriptor hashes added directly speeds up the work
+					// of building the dependency trees later.
+					state.addedIdentHashes.add(descriptor.identHash)
+
+					// To run this logic once, we wait until the last item is being processed.
+					if (state.addedTopLevelPackages[state.addedTopLevelPackages.length - 1] !== descriptor.name) {
+						return
+					}
 
 					await workspace.project.resolveEverything({
 						// FIXME: Will fail when used with unpublished tarballs.
@@ -53,23 +131,18 @@ module.exports = {
 						report: new ThrowReport(),
 					})
 
-					const nextDescriptors = workspace.project.storedDescriptors
-
-					const newDescriptors = []
-
-					for (const [descriptorHash, descriptor] of nextDescriptors.entries()) {
-						// The descriptor existed before.
-						if (currentDescriptors.has(descriptorHash)) continue
-
-						newDescriptors.push(descriptor.name)
-					}
+					const newDependencies = determineNewDependencies(
+						workspace.project.storedPackages,
+						workspace.project.storedDescriptors,
+						state.addedIdentHashes,
+					)
 
 					const rl = readline.createInterface({
 						input: process.stdin,
 						output: process.stdout,
 					})
 
-					const userInput = await new Promise((resolve) => rl.question(getPrompt(newDescriptors.length), resolve))
+					const userInput = await new Promise((resolve) => rl.question(getPrompt(newDependencies.size), resolve))
 
 					rl.close()
 


### PR DESCRIPTION
Dependency counting used to depend on comparing stored descriptors, which didn't correctly discriminate between pre-installed packages, the project's package and the new dependencies. The new method relies on the `yarn add ...` arguments and only looks at resolutions from there, which should be more accurate.