### PR TITLE
feat: better analysis support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,8 +75,6 @@ jobs:
         corepack enable
         yarn
         yarn test
-      env:
-        NO_COLOR: 1
   
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         cache-name: dependencies-cache
       with:
         path: .yarn
-        key: ${{ runner.os }}-build-${{env.cache-name}}-${{ hashFiles('**/yarn.lock') }}-node-${{ matrix.node-version }}
+        key: ${{ runner.os }}-build-${{env.cache-name}}-${{ hashFiles('./yarn.lock') }}-node-${{ matrix.node-version }}
     - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
       run: |
         corepack enable
@@ -45,7 +45,7 @@ jobs:
         cache-name: dependencies-cache
       with:
         path: .yarn
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}-node-18
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./yarn.lock') }}-node-18
     - run: |
         corepack enable  
         yarn
@@ -70,7 +70,7 @@ jobs:
         cache-name: dependencies-cache
       with:
         path: .yarn
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}-node-${{ matrix.node-version }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./yarn.lock') }}-node-${{ matrix.node-version }}
     - run: |
         corepack enable
         yarn
@@ -94,7 +94,7 @@ jobs:
         cache-name: dependencies-cache
       with:
         path: .yarn
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/yarn.lock') }}-node-${{ matrix.node-version }}
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('./yarn.lock') }}-node-${{ matrix.node-version }}
     - run: |
         corepack enable
         yarn

--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@ function isNoColourMode() {
 	return Boolean(process.env.NO_COLOR)
 }
 
-function getPrompt(descriptorsLength) {
+function getPrompt(packagesToInstall) {
 	const dependencyCount = isNoColourMode()
-		? `About to install ${descriptorsLength} new packages.\n`
-		: `About to install \x1b[1;34m${descriptorsLength}\x1b[1;0m new packages.\n`
+		? `About to install ${packagesToInstall.length} new packages.\n`
+		: `About to install \x1b[1;34m${packagesToInstall.length}\x1b[1;0m new packages.\n`
 
 	const question = isNoColourMode()
 		? 'Continue? (Y/Yes to continue, anything else to cancel): '
@@ -19,6 +19,7 @@ function getPrompt(descriptorsLength) {
 	return `${'='.repeat(10)}
     ${dependencyCount}
     ${dependencyInfo}
+    Packages: ${packagesToInstall.join(', ')}
 ${'='.repeat(10)}
 ${question}`
 }
@@ -29,8 +30,10 @@ const CANCELLATION_MESSAGE = isNoColourMode()
 
 const RESOLVE_MESSAGE =
 	'📦 Resolving direct and transitive dependencies being added...\nThis may take longer if the packages added have a lot of dependencies.'
+
 const UNKNOWN_ERROR_MESSAGE =
 	'🤔 Failed to match some dependencies while mapping new packages, results may be inaccurate.'
+
 /*
  *  Builds a collection of new dependencies based on resolved packages and known added
  *  package names.
@@ -80,10 +83,7 @@ module.exports = {
 		const { ThrowReport } = require('@yarnpkg/core')
 		const readline = require('readline')
 
-		const state = {
-			addedTopLevelPackages: undefined,
-			addedIdentHashes: new Set(),
-		}
+		let addedPackages
 
 		return {
 			hooks: {
@@ -98,38 +98,18 @@ module.exports = {
 				 * See hook documentation: https://yarnpkg.com/advanced/plugin-tutorial#hook-afterWorkspaceDependencyAddition
 				 */
 				async afterWorkspaceDependencyAddition(workspace, target, descriptor, strategies) {
-					/*
-					 * This hook is executed for each added dependency such that
-					 * `yarn add A B C` will call it thrice. To avoid this, we can
-					 * parse the command-line arguments to determine what the user is
-					 * trying to add.
-					 *
-					 * Because the hook is run multiple times, we cache the result of the
-					 * arg analysis to avoid redoing it each time.
-					 */
-					state.addedTopLevelPackages =
-						state.addedTopLevelPackages ||
-						process.argv.filter((arg, position) => {
-							// The first three arguments are the node and yarn runtime paths, and
-							// the add command.
-							if (position < 3) return false
-
-							// Flags passed to `yarn add` are ignored.
-							if (arg.startsWith('-')) return false
-
-							return true
-						})
-
-					// Keeping track of descriptor hashes added directly speeds up the work
-					// of building the dependency trees later.
-					state.addedIdentHashes.add(descriptor.identHash)
-
-					// To run this logic once, we wait until the last item is being processed.
-					if (state.addedTopLevelPackages[state.addedTopLevelPackages.length - 1] !== descriptor.name) {
-						return
-					}
+					if (addedPackages) return
 
 					process.stdout.write(`${RESOLVE_MESSAGE}\n`)
+
+					await workspace.project.resolveEverything({
+						// FIXME: Will fail when used with unpublished tarballs.
+						lockfileOnly: true,
+						// TODO: Reporting boilerplate.
+						report: new ThrowReport(),
+					})
+
+					const beforePackageLocators = new Set([...workspace.project.storedPackages.keys()])
 
 					await workspace.project.resolveEverything({
 						// FIXME: Will fail when used with unpublished tarballs.
@@ -138,18 +118,22 @@ module.exports = {
 						report: new ThrowReport(),
 					})
 
-					const newDependencies = determineNewDependencies(
-						workspace.project.storedPackages,
-						workspace.project.storedDescriptors,
-						state.addedIdentHashes,
-					)
+					const newDependencies = [...workspace.project.storedPackages.entries()]
+						.filter(([key]) => {
+							return !beforePackageLocators.has(key)
+						})
+						.map(([, packageData]) => {
+							return `${packageData.name}@${packageData.version}`
+						})
+
+					addedPackages = newDependencies
 
 					const rl = readline.createInterface({
 						input: process.stdin,
 						output: process.stdout,
 					})
 
-					const userInput = await new Promise((resolve) => rl.question(getPrompt(newDependencies.size), resolve))
+					const userInput = await new Promise((resolve) => rl.question(getPrompt(newDependencies), resolve))
 
 					rl.close()
 

--- a/index.test.js
+++ b/index.test.js
@@ -14,15 +14,15 @@ const path = require('node:path')
  */
 async function withTestPackage(testFunction) {
 	const testDirectory = await fs.mkdtemp('test-')
-
+	const defaultExecArgs = { cwd: testDirectory, encoding: 'utf8' }
 	try {
 		await fs.writeFile(path.join(testDirectory, 'package.json'), JSON.stringify({ packageManager: 'yarn@3.6.1' }))
 		await fs.copyFile('index.js', path.join(testDirectory, 'index.js'))
 		await fs.copyFile('.yarnrc.yml', path.join(testDirectory, '.yarnrc.yml'))
 		await fs.writeFile(path.join(testDirectory, 'yarn.lock'), '')
 
-		execSync('corepack enable', { cwd: testDirectory })
-		execSync('yarn', { cwd: testDirectory, encoding: 'utf8' })
+		execSync('corepack enable', defaultExecArgs)
+		execSync('yarn', defaultExecArgs)
 
 		await testFunction({ cwd: testDirectory })
 		await fs.rm(testDirectory, { recursive: true })

--- a/index.test.js
+++ b/index.test.js
@@ -1,7 +1,7 @@
 const { describe, test } = require('node:test')
 const assert = require('node:assert')
 const { promises: fs } = require('node:fs')
-const { exec, spawn } = require('node:child_process')
+const { exec, spawn, execSync } = require('node:child_process')
 const path = require('node:path')
 
 /*
@@ -21,8 +21,8 @@ async function withTestPackage(testFunction) {
 		await fs.copyFile('.yarnrc.yml', path.join(testDirectory, '.yarnrc.yml'))
 		await fs.writeFile(path.join(testDirectory, 'yarn.lock'), '')
 
-		await exec('corepack enable', { cwd: testDirectory })
-		await exec('yarn', { cwd: testDirectory })
+		execSync('corepack enable', { cwd: testDirectory })
+		execSync('yarn', { cwd: testDirectory, encoding: 'utf8' })
 
 		await testFunction({ cwd: testDirectory })
 		await fs.rm(testDirectory, { recursive: true })

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "yarn rome format *.js && yarn rome check *.js",
     "lint:fix": "yarn rome format *.js --write && yarn rome check *.js --apply",
     "lint:fix-more": "yarn rome format *.js --write && yarn rome check *.js --apply-unsafe",
-    "test": "yarn build && yarn node --test",
+    "test": "yarn node --test",
     "build": "yarn pack"
   },
   "devDependencies": {


### PR DESCRIPTION
This changes the way the plugin figures out the added dependencies: prior to this, the command-line arguments we're parsed to determine what was meant to be added, and the packages + transitive dependencies were determined from there. With this, we first do a resolution based on the lockfile data only (i.e. installed packages), then do a full resolution (lockfile+network) and compare the two. This is more robust in that it doesn't depend on haphazard parsing of arguments passed to `yarn add`.

This still does not support installing local tarballs.